### PR TITLE
Limit branch CI builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ install: npm ci
 script:
   - npm run lint
   - npm run test:with-coverage
+
+# Will still run for PRs if configured
+# in TravisCI UI options.
+branches:
+  only:
+    - master


### PR DESCRIPTION
# Summary

Limit branch CI builds to master. This removes duplicate builds on PRs, but still keeps the `master` branch details (e.g. metadata: build status, code coverage, etc) up to date. 